### PR TITLE
fix(android): ensure WebView print operations run on UI thread

### DIFF
--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -139,7 +139,8 @@ public class Printer {
         if (webView == null) {
             throw new Exception("WebView not available");
         }
-        createWebPrintJob(webView, name);
+        // Ensure WebView operations run on the UI thread
+        activity.runOnUiThread(() -> createWebPrintJob(webView, name));
     }
 
     // MARK: - Private Helper Methods


### PR DESCRIPTION
This PR fixes the "WebView method was called on thread 'CapacitorPlugins'" when printing the webview page.

Identified the issue and checked the fix on Android 12. Did not test any other devices.

## Changes:
- Wrap createWebPrintJob call in runOnUiThread to prevent java.lang.RuntimeException: java.lang.Throwable: A WebView method was called on thread 'CapacitorPlugins'. All WebView methods must be called on the same thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the Android print functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->