### PR TITLE
fix: Run createWebPrintJob on UI thread when using printWebView

### DIFF
--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -145,7 +145,14 @@ public class Printer {
         if (webView == null) {
             throw new Exception("WebView not available");
         }
-        createWebPrintJob(webView, name);
+        activity.runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        createWebPrintJob(webView, name);
+                    }
+                }
+        );
     }
 
     // MARK: - Private Helper Methods

--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -146,12 +146,12 @@ public class Printer {
             throw new Exception("WebView not available");
         }
         activity.runOnUiThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        createWebPrintJob(webView, name);
-                    }
+            new Runnable() {
+                @Override
+                public void run() {
+                    createWebPrintJob(webView, name);
                 }
+            }
         );
     }
 


### PR DESCRIPTION
Hello! 

When printing a job on Android using printWebView, the following error would be thrown:

`Failed to print web view: java.lang.Throwable: A WebView method was called on thread 'CapacitorPlugins'. All WebView methods must be called on the same thread. (Expected Looper Looper (main, tid 2) {f1df0f6} called on Looper (CapacitorPlugins, tid 88) {f75b856}, FYI main Looper is Looper (main, tid 2) {f1df0f6})`

Making createWebPrintJob run on the UI thread, as the error said, resolved this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web-view printing reliability: print jobs are now executed on the proper UI thread, reducing intermittent failures and inconsistent print behavior. Users should experience more consistent print results and fewer errors when initiating prints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->