### PR TITLE
fix(android): run printWebView on UI thread

### DIFF
--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -145,7 +145,14 @@ public class Printer {
         if (webView == null) {
             throw new Exception("WebView not available");
         }
-        createWebPrintJob(webView, name);
+        activity.runOnUiThread(
+            new Runnable() {
+                @Override
+                public void run() {
+                    createWebPrintJob(webView, name);
+                }
+            }
+        );
     }
 
     // MARK: - Private Helper Methods


### PR DESCRIPTION
## Summary
- Run `createWebPrintJob` on the Android UI thread when `printWebView` is called
- Prevents the WebView thread error reported on Capacitor 8 Android

Closes #17

## Test plan
- [ ] Call `Printer.printWebView()` on Android and confirm the print dialog opens without a thread exception
- [ ] Verify `printHtml` and other print methods still work on Android

Made with [Cursor](https://cursor.com)