### PR TITLE
fix(web): keep Chrome PDF print dialog open

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -9,11 +9,14 @@ import type {
   PrinterPlugin,
 } from './definitions';
 
+const PDF_PRINT_DELAY_MS = 500;
+const HTML_PRINT_DELAY_MS = 100;
+const CLEANUP_FALLBACK_MS = 60_000;
+
 export class PrinterWeb extends WebPlugin implements PrinterPlugin {
   async printBase64(options: PrintBase64Options): Promise<void> {
     const { data, mimeType, name } = options;
 
-    // Convert base64 to blob
     const byteCharacters = atob(data);
     const byteNumbers = new Array(byteCharacters.length);
     for (let i = 0; i < byteCharacters.length; i++) {
@@ -22,48 +25,44 @@ export class PrinterWeb extends WebPlugin implements PrinterPlugin {
     const byteArray = new Uint8Array(byteNumbers);
     const blob = new Blob([byteArray], { type: mimeType });
 
-    // Create object URL and print
     const url = URL.createObjectURL(blob);
-    await this.printFromUrl(url, name);
-    URL.revokeObjectURL(url);
+    try {
+      await this.printFromUrl(url, name, mimeType);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   }
 
   async printFile(options: PrintFileOptions): Promise<void> {
-    const { path, name } = options;
-
-    // On web, we can only print URLs that are accessible
-    // This will work for file:// URLs in some browsers or HTTP(S) URLs
-    await this.printFromUrl(path, name);
+    const { path, name, mimeType } = options;
+    await this.printFromUrl(path, name, mimeType);
   }
 
   async printHtml(options: PrintHtmlOptions): Promise<void> {
     const { html, name } = options;
 
-    // Create a blob URL from the HTML content
     const blob = new Blob([html], { type: 'text/html' });
     const url = URL.createObjectURL(blob);
-    await this.printFromUrl(url, name);
-    URL.revokeObjectURL(url);
+    try {
+      await this.printFromUrl(url, name, 'text/html');
+    } finally {
+      URL.revokeObjectURL(url);
+    }
   }
 
   async printPdf(options: PrintPdfOptions): Promise<void> {
     const { path, name } = options;
-
-    // On web, print the PDF URL
-    await this.printFromUrl(path, name);
+    await this.printFromUrl(path, name, 'application/pdf');
   }
 
   async printWebView(options?: PrintOptions): Promise<void> {
-    // Set document title for print job name
     const originalTitle = document.title;
     if (options?.name) {
       document.title = options.name;
     }
 
-    // Trigger browser print dialog
     window.print();
 
-    // Restore original title
     document.title = originalTitle;
   }
 
@@ -71,9 +70,8 @@ export class PrinterWeb extends WebPlugin implements PrinterPlugin {
     return { version: '7.0.0' };
   }
 
-  private async printFromUrl(url: string, name?: string): Promise<void> {
+  private async printFromUrl(url: string, name?: string, mimeType?: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      // Create hidden iframe
       const iframe = document.createElement('iframe');
       iframe.style.position = 'fixed';
       iframe.style.right = '0';
@@ -82,49 +80,50 @@ export class PrinterWeb extends WebPlugin implements PrinterPlugin {
       iframe.style.height = '0';
       iframe.style.border = 'none';
 
-      // Set up load handler
-      iframe.onload = () => {
-        try {
-          // Set document title if name provided
-          if (name && iframe.contentDocument) {
-            iframe.contentDocument.title = name;
-          }
-
-          // Small delay to ensure content is loaded
-          setTimeout(() => {
-            try {
-              // Try to access the iframe's window
-              const iframeWindow = iframe.contentWindow;
-              if (!iframeWindow) {
-                throw new Error('Cannot access iframe window');
-              }
-
-              // Print the iframe content
-              iframeWindow.focus();
-              iframeWindow.print();
-
-              // Clean up after a delay
-              setTimeout(() => {
-                document.body.removeChild(iframe);
-                resolve();
-              }, 100);
-            } catch (error) {
-              document.body.removeChild(iframe);
-              reject(error);
-            }
-          }, 100);
-        } catch (error) {
-          document.body.removeChild(iframe);
-          reject(error);
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) {
+          return;
         }
+        cleanedUp = true;
+        if (iframe.parentNode) {
+          document.body.removeChild(iframe);
+        }
+        resolve();
+      };
+
+      const printDelayMs = mimeType?.toLowerCase() === 'application/pdf' ? PDF_PRINT_DELAY_MS : HTML_PRINT_DELAY_MS;
+
+      iframe.onload = () => {
+        window.setTimeout(() => {
+          try {
+            const iframeWindow = iframe.contentWindow;
+            if (!iframeWindow) {
+              throw new Error('Cannot access iframe window');
+            }
+
+            if (name && iframe.contentDocument) {
+              iframe.contentDocument.title = name;
+            }
+
+            iframeWindow.addEventListener('afterprint', () => cleanup(), { once: true });
+            iframeWindow.focus();
+            iframeWindow.print();
+            window.setTimeout(() => cleanup(), CLEANUP_FALLBACK_MS);
+          } catch (error) {
+            cleanup();
+            reject(error);
+          }
+        }, printDelayMs);
       };
 
       iframe.onerror = () => {
-        document.body.removeChild(iframe);
+        if (iframe.parentNode) {
+          document.body.removeChild(iframe);
+        }
         reject(new Error('Failed to load content for printing'));
       };
 
-      // Add iframe to document and set source
       document.body.appendChild(iframe);
       iframe.src = url;
     });


### PR DESCRIPTION
## Summary
- Wait longer before printing PDF blobs in Chrome so the PDF viewer can load
- Clean up the hidden print iframe on `afterprint` instead of a fixed 100ms timeout
- Keeps the print dialog visible until the user finishes printing

Closes #15

## Test plan
- [ ] Run the example app with `bun run preview` in Chrome
- [ ] Click **Print Base64 PDF** and confirm the print dialog stays open
- [ ] Confirm HTML and image printing still work in Chrome and Safari

Made with [Cursor](https://cursor.com)