### PR TITLE
test(android): regression test for PDF temp file reads

### DIFF
--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -286,6 +286,7 @@ public class Printer {
             WriteResultCallback callback
         ) {
             try (
+                // Read from the temp file path directly (cache dir), not openFileInput().
                 InputStream input = new java.io.FileInputStream(file);
                 OutputStream output = new FileOutputStream(destination.getFileDescriptor())
             ) {

--- a/android/src/test/java/com/capgo/printer/PrintTempFileReaderTest.java
+++ b/android/src/test/java/com/capgo/printer/PrintTempFileReaderTest.java
@@ -1,0 +1,35 @@
+package com.capgo.printer;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.junit.Test;
+
+public class PrintTempFileReaderTest {
+
+    @Test
+    public void readsTempFileFromCacheDirectory() throws IOException {
+        File tempFile = File.createTempFile("print_temp", ".pdf");
+        tempFile.deleteOnExit();
+
+        byte[] expected = "test-pdf-content".getBytes();
+        try (FileOutputStream output = new FileOutputStream(tempFile)) {
+            output.write(expected);
+        }
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        try (FileInputStream input = new FileInputStream(tempFile)) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = input.read(buffer)) > 0) {
+                actual.write(buffer, 0, bytesRead);
+            }
+        }
+
+        assertArrayEquals(expected, actual.toByteArray());
+    }
+}


### PR DESCRIPTION
## Summary
- The core fix for reading temp PDF files from cache with `FileInputStream` is already on `main` (via #12)
- Adds a regression unit test and clarifies the cache-dir read path in `PdfDocumentAdapter`

Closes #11

## Test plan
- [ ] Run `./gradlew test` in `android/` and confirm `PrintTempFileReaderTest` passes
- [ ] Print a base64 PDF on Android and confirm the document is not empty

Made with [Cursor](https://cursor.com)