### PR TITLE
feat: add printIframe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ await Printer.printWebView({
 * [`printFile(...)`](#printfile)
 * [`printHtml(...)`](#printhtml)
 * [`printPdf(...)`](#printpdf)
+* [`printIframe(...)`](#printiframe)
 * [`printWebView(...)`](#printwebview)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
@@ -216,35 +217,39 @@ Presents the printing UI to print PDF documents.
 --------------------
 
 
+### printIframe(...)
+
+```typescript
+printIframe(options: PrintIframeOptions) => Promise<void>
+```
+
+Presents the printing UI for content inside an iframe element.
+
+Useful when the full HTML document is too large to pass to printHtml().
+
+**Platform Behavior:**
+- **iOS**: Evaluates JavaScript in the WebView to print the iframe content
+- **Android**: Evaluates JavaScript in the WebView to print the iframe content
+- **Web**: Finds the iframe and triggers its print dialog
+
+| Param         | Type                                                              | Description                                |
+| ------------- | ----------------------------------------------------------------- | ------------------------------------------ |
+| **`options`** | <code><a href="#printiframeoptions">PrintIframeOptions</a></code> | - CSS selector and optional print job name |
+
+**Since:** 8.0.19
+
+--------------------
+
+
 ### printWebView(...)
 
 ```typescript
 printWebView(options?: PrintOptions | undefined) => Promise<void>
 ```
 
-Presents the printing UI to print web view content.
-
-Prints the current content displayed in your app's web view.
-
-**Platform Behavior:**
-- **iOS**: Uses UIPrintInteractionController with WKWebView's view printable
-- **Android**: Uses WebView.createPrintDocumentAdapter() with PrintManager
-- **Web**: Triggers window.print() for current page
-
-**Print Styling:**
-Supports CSS print media queries for customization. The web view's current
-styles will be applied, including any @media print rules.
-
-**Use Cases:**
-- Print the current app screen/page
-- Print web-based reports or dashboards
-- Print user-generated content displayed in web view
-
-| Param         | Type                                                  | Description                                       |
-| ------------- | ----------------------------------------------------- | ------------------------------------------------- |
-| **`options`** | <code><a href="#printoptions">PrintOptions</a></code> | - Optional configuration for printing (name only) |
-
-**Since:** 7.0.0
+| Param         | Type                                                  |
+| ------------- | ----------------------------------------------------- |
+| **`options`** | <code><a href="#printoptions">PrintOptions</a></code> |
 
 --------------------
 
@@ -307,6 +312,15 @@ Options for printing PDF documents.
 | Prop       | Type                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Since |
 | ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
 | **`path`** | <code>string</code> | Path to the PDF document. **iOS Path Formats:** - `file://` URL: Full file URL path to PDF document - Relative path: Path relative to app's documents directory - Must be within app's accessible directories (documents, temporary, cache) - PDF must be valid and not password-protected **Android Path Formats:** - `content://` URI: Content provider URI (recommended for external PDFs) - `file://` path: Direct file system path to PDF - Must have read permission for the file - Supports both single-page and multi-page PDFs **Web Path Formats:** - Relative or absolute path accessible from web context - Must be a valid PDF file **Validation:** - File must exist at the specified path - File must be a valid PDF (checked by magic number/header) - File must be readable by the app **Common Sources:** - App documents: PDFs saved in app's document directory - Downloads: PDFs from system downloads (use content:// on Android) - Generated PDFs: Temporary PDFs created by the app - Network downloads: PDFs downloaded and saved locally | 7.0.0 |
+
+
+#### PrintIframeOptions
+
+Options for printing iframe content.
+
+| Prop           | Type                | Description                                                                                                    | Since  |
+| -------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- | ------ |
+| **`selector`** | <code>string</code> | CSS selector for the iframe element to print. The selector must match a single iframe in the current document. | 8.0.19 |
 
 
 #### PrintOptions

--- a/android/src/main/java/com/capgo/printer/Printer.java
+++ b/android/src/main/java/com/capgo/printer/Printer.java
@@ -141,6 +141,32 @@ public class Printer {
         }
     }
 
+    public void printIframe(WebView webView, String selector, String name) throws Exception {
+        if (webView == null) {
+            throw new Exception("WebView not available");
+        }
+
+        String escapedSelector = org.json.JSONObject.quote(selector);
+        String escapedName = org.json.JSONObject.quote(name);
+        final String script =
+            "(function(){var frame=document.querySelector(" +
+            escapedSelector +
+            ");if(!frame||!frame.contentWindow){throw new Error('iframe not found');}if(" +
+            escapedName +
+            "){document.title=" +
+            escapedName +
+            ";}frame.contentWindow.focus();frame.contentWindow.print();})()";
+
+        activity.runOnUiThread(
+            new Runnable() {
+                @Override
+                public void run() {
+                    webView.evaluateJavascript(script, null);
+                }
+            }
+        );
+    }
+
     public void printWebView(WebView webView, String name) throws Exception {
         if (webView == null) {
             throw new Exception("WebView not available");

--- a/android/src/main/java/com/capgo/printer/PrinterPlugin.java
+++ b/android/src/main/java/com/capgo/printer/PrinterPlugin.java
@@ -98,6 +98,24 @@ public class PrinterPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void printIframe(PluginCall call) {
+        String selector = call.getString("selector");
+        String name = call.getString("name", "Document");
+
+        if (selector == null) {
+            call.reject("selector is required");
+            return;
+        }
+
+        try {
+            implementation.printIframe(getBridge().getWebView(), selector, name);
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("Failed to print iframe: " + e.getMessage(), e);
+        }
+    }
+
+    @PluginMethod
     public void printWebView(PluginCall call) {
         String name = call.getString("name", "Document");
 

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -145,6 +145,18 @@
   </div>
 
   <div class="section">
+    <h2>Print Iframe Content</h2>
+    <p>Print only the content inside the iframe below.</p>
+    <iframe
+      id="demo-iframe"
+      title="Demo iframe"
+      style="width: 100%; height: 180px; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 10px;"
+      srcdoc="&lt;html&gt;&lt;body style='font-family: Arial, sans-serif; padding: 16px;'&gt;&lt;h3&gt;Iframe Document&lt;/h3&gt;&lt;p&gt;Only this iframe content will be sent to the printer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+    ></iframe>
+    <button onclick="printIframeDemo()">Print Iframe</button>
+  </div>
+
+  <div class="section">
     <h2>Print Base64 PDF</h2>
     <p>Print a small base64 encoded PDF.</p>
     <button onclick="printBase64Pdf()">Print Base64 PDF</button>

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -60,6 +60,20 @@ window.printBase64Image = async function () {
   }
 };
 
+// Print iframe content
+window.printIframeDemo = async function () {
+  try {
+    await Printer.printIframe({
+      selector: '#demo-iframe',
+      name: 'Iframe Document',
+    });
+    showStatus('Print dialog opened successfully!');
+  } catch (error) {
+    console.error('Error printing iframe:', error);
+    showStatus('Error: ' + error.message, true);
+  }
+};
+
 // Print base64 PDF (minimal PDF)
 window.printBase64Pdf = async function () {
   try {

--- a/ios/Sources/PrinterPlugin/Printer.swift
+++ b/ios/Sources/PrinterPlugin/Printer.swift
@@ -142,6 +142,38 @@ import WebKit
         )
     }
 
+    /// Print iframe content from the current web view
+    public func printIframe(
+        webView: WKWebView,
+        selector: String,
+        name: String
+    ) throws {
+        let escapedSelector = selector
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\'", with: "\\\'")
+        let escapedName = name
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\'", with: "\\\'")
+
+        let script = """
+        (function() {
+            var frame = document.querySelector('\\(escapedSelector)');
+            if (!frame || !frame.contentWindow) {
+                throw new Error('iframe not found');
+            }
+            if ('\\(escapedName)') {
+                document.title = '\\(escapedName)';
+            }
+            frame.contentWindow.focus();
+            frame.contentWindow.print();
+        })();
+        """
+
+        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
     /// Print web view content
     public func printWebView(
         webView: WKWebView,

--- a/ios/Sources/PrinterPlugin/PrinterPlugin.swift
+++ b/ios/Sources/PrinterPlugin/PrinterPlugin.swift
@@ -11,6 +11,7 @@ public class PrinterPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "printFile", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "printHtml", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "printPdf", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "printIframe", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "printWebView", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
@@ -115,6 +116,34 @@ public class PrinterPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.resolve()
             } catch {
                 call.reject("Failed to print PDF: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @objc func printIframe(_ call: CAPPluginCall) {
+        guard let selector = call.getString("selector") else {
+            call.reject("selector is required")
+            return
+        }
+
+        let name = call.getString("name") ?? "Document"
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            guard let webView = self.bridge?.webView else {
+                call.reject("WebView not available")
+                return
+            }
+
+            do {
+                try self.implementation.printIframe(
+                    webView: webView,
+                    selector: selector,
+                    name: name
+                )
+                call.resolve()
+            } catch {
+                call.reject("Failed to print iframe: \(error.localizedDescription)")
             }
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -211,6 +211,31 @@ export interface PrinterPlugin {
    * });
    * ```
    */
+
+  /**
+   * Presents the printing UI for content inside an iframe element.
+   *
+   * Useful when the full HTML document is too large to pass to printHtml().
+   *
+   * **Platform Behavior:**
+   * - **iOS**: Evaluates JavaScript in the WebView to print the iframe content
+   * - **Android**: Evaluates JavaScript in the WebView to print the iframe content
+   * - **Web**: Finds the iframe and triggers its print dialog
+   *
+   * @param options - CSS selector and optional print job name
+   * @returns Promise that resolves when print dialog is dismissed
+   * @throws Error if the iframe is not found or printing fails
+   * @since 8.0.19
+   * @example
+   * ```typescript
+   * await Printer.printIframe({
+   *   selector: '#report-frame',
+   *   name: 'Monthly Report',
+   * });
+   * ```
+   */
+  printIframe(options: PrintIframeOptions): Promise<void>;
+
   printWebView(options?: PrintOptions): Promise<void>;
 
   /**
@@ -497,4 +522,23 @@ export interface PrintOptions {
  *
  * @since 7.0.0
  */
+
+/**
+ * Options for printing iframe content.
+ *
+ * @since 8.0.19
+ */
+export interface PrintIframeOptions extends PrintOptions {
+  /**
+   * CSS selector for the iframe element to print.
+   *
+   * The selector must match a single iframe in the current document.
+   *
+   * @since 8.0.19
+   * @example '#report-frame'
+   * @example 'iframe[name="invoice"]'
+   */
+  selector: string;
+}
+
 export type PrintWebViewOptions = PrintOptions;

--- a/src/web.ts
+++ b/src/web.ts
@@ -5,6 +5,7 @@ import type {
   PrintFileOptions,
   PrintHtmlOptions,
   PrintOptions,
+  PrintIframeOptions,
   PrintPdfOptions,
   PrinterPlugin,
 } from './definitions';
@@ -51,6 +52,25 @@ export class PrinterWeb extends WebPlugin implements PrinterPlugin {
 
     // On web, print the PDF URL
     await this.printFromUrl(path, name);
+  }
+
+  async printIframe(options: PrintIframeOptions): Promise<void> {
+    const { selector, name } = options;
+    const iframe = document.querySelector(selector);
+
+    if (!(iframe instanceof HTMLIFrameElement) || !iframe.contentWindow) {
+      throw new Error(`iframe not found: ${selector}`);
+    }
+
+    const originalTitle = document.title;
+    if (name) {
+      document.title = name;
+    }
+
+    iframe.contentWindow.focus();
+    iframe.contentWindow.print();
+
+    document.title = originalTitle;
   }
 
   async printWebView(options?: PrintOptions): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds `Printer.printIframe({ selector, name })` on iOS, Android, and Web
- Native platforms evaluate JavaScript in the Capacitor WebView to print iframe content
- Example app includes an iframe demo section

Closes #1

## Test plan
- [ ] Open the example app and click **Print Iframe**
- [ ] Confirm only the iframe content is sent to the print dialog on Web
- [ ] Confirm the method works on iOS and Android with an iframe in the WebView

Made with [Cursor](https://cursor.com)